### PR TITLE
Fix Typo: $servicesStatuses -> $serviceStatuses

### DIFF
--- a/SharePointDSC.Reverse.ps1
+++ b/SharePointDSC.Reverse.ps1
@@ -2056,7 +2056,7 @@ function Read-SPServiceInstance($Servers)
         {
             Add-ConfigurationDataEntry -Node $env:ComputerName -Key "ServiceInstances" -Value $serviceStatuses
         }
-        elseif ($servicesStatuses.Length -gt 0)
+        elseif ($serviceStatuses.Length -gt 0)
         {
             Add-ConfigurationDataEntry -Node $Server -Key "ServiceInstances" -Value $serviceStatuses
         }


### PR DESCRIPTION
Fix a typo that causes ServiceInstances not being written to ConfigurationData
Fixes #99 